### PR TITLE
clearOnRoute fix

### DIFF
--- a/src/flashes/model.js
+++ b/src/flashes/model.js
@@ -15,6 +15,7 @@ module.exports = Model.extend({
     }
 
     this.on('destroy', this._clearTimeout);
+    this.on('destroy', this.stopListening);
 
     if (this.get('clearOnRoute')) {
       this.listenTo(Backbone.history, 'route', this.destroy);

--- a/src/flashes/model.js
+++ b/src/flashes/model.js
@@ -2,8 +2,6 @@ var _ = require('underscore');
 var Radio = require('backbone.radio');
 var Model = require('../classes/model');
 
-var routerChannel = Radio.channel('router');
-
 module.exports = Model.extend({
   defaults: {
     timeout: false,
@@ -12,6 +10,7 @@ module.exports = Model.extend({
   },
 
   initialize: function() {
+    var self = this;
     if (this.get('timeout') !== false) {
       this._setTimeout();
     }
@@ -19,7 +18,7 @@ module.exports = Model.extend({
     this.on('destroy', this._clearTimeout);
 
     if (this.get('clearOnRoute')) {
-      this.listenTo(routerChannel, 'route', this.destroy);
+      Backbone.history.on('route', function(router, route, params) {self.destroy();});
     }
   },
 

--- a/src/flashes/model.js
+++ b/src/flashes/model.js
@@ -10,7 +10,6 @@ module.exports = Model.extend({
   },
 
   initialize: function() {
-    var self = this;
     if (this.get('timeout') !== false) {
       this._setTimeout();
     }
@@ -18,7 +17,7 @@ module.exports = Model.extend({
     this.on('destroy', this._clearTimeout);
 
     if (this.get('clearOnRoute')) {
-      Backbone.history.on('route', function(router, route, params) {self.destroy();});
+      this.listenTo(Backbone.history, 'route', this.destroy);
     }
   },
 

--- a/test/unit/flashes/model.spec.js
+++ b/test/unit/flashes/model.spec.js
@@ -40,19 +40,17 @@ describe('flashes/model.js', function() {
 
     describe('when "clearOnRoute" is true', function() {
       beforeEach(function() {
-        this.routerChannel = Backbone.Radio.channel('router');
         this.model.initialize();
       });
 
       it('should listen for "route" events', function() {
         expect(this.model.listenTo)
-          .to.have.been.calledWith(this.routerChannel, 'route', this.model.destroy);
+          .to.have.been.calledWith(Backbone.history, 'route', this.model.destroy);
       });
     });
 
     describe('when "clearOnRoute" is false', function() {
       beforeEach(function() {
-        this.routerChannel = Backbone.Radio.channel('router');
         this.model.attributes.clearOnRoute = false;
         this.model.initialize();
       });


### PR DESCRIPTION
Since the routerChannel is not used anywhere else in right now, and the clearOnRoute therefore is broken. Fix  by listening to `Backbone.history`.