### PR TITLE
remove get

### DIFF
--- a/src/colors/create/view.js
+++ b/src/colors/create/view.js
@@ -30,7 +30,7 @@ export default class ColorsCreateView extends View {
     _.bindAll(this, 'handleSaveSuccess');
   }
 
-  get events() {
+  events() {
     return {
       'submit form': 'handleSubmit'
     };


### PR DESCRIPTION
Fixes an error when trying to create a new color. 

Here is the error when clicking 'Create'
Uncaught TypeError: Cannot set property events of #<ColorsCreateView> which has only a getter