### PR TITLE
Fix invalid link in documentation. Fixes #28

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ As a general rule, be sure to read through all of the source code yourself and m
 | ---:|:--- |
 | [api](./api) | Mock api routes |
 | [dist](./dist) | Built assets |
-| [lib](./lib) | Libraries (only ones not on npm) |
+| lib | Libraries (only ones not on npm) |
 | [src](./src) | Source files |
 | [test](./test) | Test files |
 


### PR DESCRIPTION
Trivial PR with small change in project documentation file.
The lib directory is not yet part of repository or part of build or install routines. 
It would be better to remove this part completely in future versions or mark it as WIP
Thanks!