### PR TITLE
Bundle browserify (through watchify) in the watch gulp task

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -110,10 +110,10 @@ gulp.task('watch', ['build'], function(cb) {
   });
 
   reporter = 'dot';
-  bundler(cb, true).on('update', function() {
+  bundler(true).on('update', function() {
     gulp.start('scripts');
     gulp.start('test');
-  });
+  }).bundle();
   gulp.watch('./test/**/*.js', ['test']);
   gulp.watch(['./src/main.less', './src/**/*.less'], ['styles']);
   gulp.watch(['./src/*.html'], ['html']);


### PR DESCRIPTION
The `watch` gulp task was broken. It used to call `bundler` with the inappropriate parameters and it did not call `bundle`.

```
bundler(cb, true).on('update', function() {
//...
});
```

This did not allow a reload of the `scripts` or `test` tasks to occur when a js file was updated. The change fires off `watchify`:

```
bundler(true).on('update', function() {
//...
}).bundle();
```