### PR TITLE
Bundler takes one argument

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -110,7 +110,7 @@ gulp.task('watch', ['build'], function(cb) {
   });
 
   reporter = 'dot';
-  bundler(cb, true).on('update', function() {
+  bundler(true).on('update', function() {
     gulp.start('scripts');
     gulp.start('test');
   });


### PR DESCRIPTION
Bundler takes one argument. Now watchify works correctly and can see changes in files.