### PR TITLE
Fix modal

### DIFF
--- a/src/modal/layout-view.js
+++ b/src/modal/layout-view.js
@@ -19,7 +19,7 @@ export default LayoutView.extend({
     'hidden.bs.modal' : 'modal:hide',
   },
 
-  initialize() {
+  onShow() {
     this.$el.modal({
       show: false,
       backdrop: 'static'


### PR DESCRIPTION
Fixed this issue https://github.com/thejameskyle/marionette-wires/issues/60
When you initialize bootstrap modal, .modal-dialog element is not exist yet, and bootstrap can't fire event 'shown.bs.modal'. So you need to initialize modal after rendering template or you can remove fade class.