### PR TITLE
Fix modals not showing after closing one of them using Esc key

### DIFF
--- a/src/modal/service.js
+++ b/src/modal/service.js
@@ -22,6 +22,7 @@ const WiresModalService = ModalService.extend({
 
   render(view) {
     this.layout.content.show(view);
+    this.layout.animateIn();
   },
 
   remove() {


### PR DESCRIPTION
Not sure if this is a proper place to fix this.

The issue is that after closing one of modal dialogs using Esc key, no other modal dialogs can be opened until page is refreshed. This is what I had in my project.

In marionette-wires.com it's a bit different. Pressing Esc closes dialog, trying to click to open it again does nothing, second click opens two of the same modal dialog.
